### PR TITLE
Corrected plugin's name

### DIFF
--- a/Here.py
+++ b/Here.py
@@ -5,7 +5,7 @@ import re
 PLUGIN_METADATA = {
 	'id': 'here',
 	'version': '1.0.0',
-	'name': 'Carpet Feature Helper',
+	'name': 'Here',
 	'author': [
 		'Fallen_Breath',
 		'nathan21hz'


### PR DESCRIPTION
`PLUGIN_METADATA`中的`name`写错了
已将`Carpet Feature Helper`改为`Here`